### PR TITLE
✨ Automerge les packages NPM de Ruby on Rails

### DIFF
--- a/preset/automergeRecommendedNPM.json
+++ b/preset/automergeRecommendedNPM.json
@@ -22,7 +22,10 @@
         "vue",
         "vue-router",
         "@ionic/lab",
-        "@vue/test-utils"
+        "@vue/test-utils",
+        "@rails/activestorage",
+        "@rails/ujs",
+        "@hotwired/turbo-rails"
       ],
       "matchPackagePrefixes": ["@capacitor/", "@sentry/"]
     }


### PR DESCRIPTION
- @rails/activestorage
- @rails/ujs

Cela fait suite à cette PR : https://github.com/Captive-Studio/vesta/pull/273

Il n'y a pas vraiment de changement et ruby on rails est reconnu pour sa fiabilité