### PR TITLE
🔧 Ajoute la config d'automerge pour activestorage de v 7.x à 8.x.

### DIFF
--- a/preset/automergeRecommendedGems.json
+++ b/preset/automergeRecommendedGems.json
@@ -17,6 +17,15 @@
       "matchManagers": ["bundler"],
       "matchPackageNames": ["shoulda-matchers"],
       "automerge": true
+    },
+    {
+      "description": "Automerge ActiveStorage en major pour 7.x → 8.x uniquement",
+      "matchManagers": ["bundler"],
+      "matchPackageNames": ["activestorage"],
+      "matchUpdateTypes": ["major"],
+      "matchCurrentVersion": "/^7\\./",
+      "allowedVersions": ">=8.0.0 <9.0.0",
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
Il n'y a pas de breaking changes sur ces montées de version