### PR TITLE
🔧 Désactiver l'automerge pour react-native-signature-canvas

### DIFF
--- a/preset/suspectNPMDependencies.json
+++ b/preset/suspectNPMDependencies.json
@@ -2,6 +2,27 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
     {
+      "matchPackageNames": ["react-native-signature-canvas"],
+      "matchManagers": ["npm"],
+      "matchNewValue": "/^5\\.0\\.2$/",
+      "addLabels": ["warning"],
+      "dependencyDashboardApproval": true,
+      "automerge": false,
+      "prBodyNotes": [
+        "🚫 Cette version introduit un bug connu. Ne pas merger. https://github.com/YanYuanFE/react-native-signature-canvas/pull/430"
+      ]
+    },
+    {
+      "matchPackageNames": ["react-native-signature-canvas"],
+      "matchManagers": ["npm"],
+      "matchCurrentVersion": "5.0.2",
+      "addLabels": ["warning"],
+      "automerge": false,
+      "prBodyNotes": [
+        "⚠️ Vérifier que le correctif du bug introduit en v5.0.2 est bien présent. https://github.com/YanYuanFE/react-native-signature-canvas/pull/430"
+      ]
+    },
+    {
       "matchPackageNames": ["axios"],
       "matchUpdateTypes": ["major", "minor"],
       "matchManagers": ["npm"],


### PR DESCRIPTION
 (suite a un bug sur une version patchée - 5.0.2)
 
 