### PR TITLE
✨ Automerge solid_cable 3.x → 4.x

### DIFF
--- a/preset/automergeRecommendedGems.json
+++ b/preset/automergeRecommendedGems.json
@@ -25,6 +25,14 @@
       "matchCurrentVersion": "/^7\\./",
       "allowedVersions": ">=8.0.0 <9.0.0",
       "automerge": true
+    },
+    {
+      "description": "Automerge solid_cable en major pour 3.x → 4.x uniquement (pas de changement cassant hors drop Ruby 3.1)",
+      "matchManagers": ["bundler"],
+      "matchPackageNames": ["solid_cable"],
+      "matchCurrentVersion": "/^3\\./",
+      "allowedVersions": ">=4.0.0 <5.0.0",
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
## Changement

Ajout d'une règle d'automerge pour `solid_cable` lors du passage de la version 3.x à la version 4.x.

## Pourquoi

La v4 de `solid_cable` ne contient pas de changement cassant fonctionnel. Le seul breaking change est le **drop du support de Ruby 3.1**, qui sera naturellement bloqué par les tests CI des applications concernées.

La règle est bornée (`>=4.0.0 <5.0.0`) pour éviter tout automerge non voulu vers les versions futures.

## Pattern utilisé

Identique à la règle existante pour `activestorage` (7.x → 8.x).