### PR TITLE
✨ Ajouter un avertissement facturation pour les MàJ du package expo

### DIFF
--- a/preset/groupExpo.json
+++ b/preset/groupExpo.json
@@ -32,6 +32,12 @@
       ]
     },
     {
+      "matchPackageNames": ["expo"],
+      "prBodyNotes": [
+        "⚠️ Vous pouvez clore cette PR. La mise à jour de Expo Go est une mise à jour facturable (au même titre que les mises à jour de Rails)"
+      ]
+    },
+    {
       "description": "Ne pas mettre à jour les deps verrouillées par Expo",
       "matchPackageNames": [
         "@react-native-community/netinfo",


### PR DESCRIPTION
## Contexte

La mise à jour du package npm `expo` (SDK principal) entraîne une mise à jour de Expo Go, qui est une opération facturable (comme les mises à jour de Rails).

## Changement

Ajout d'un `prBodyNotes` spécifique au package `expo` dans `preset/groupExpo.json`, qui avertit les reviewers qu'ils peuvent clore la PR car la mise à jour est facturable.

Ce message s'affiche **uniquement** quand le package `expo` est mis à jour, en complément du message existant sur la vérification de compatibilité Expo Go.

## Message ajouté

> ⚠️ Vous pouvez clore cette PR. La mise à jour de Expo Go est une mise à jour facturable (au même titre que les mises à jour de Rails)