### PR TITLE
🔧 Ajouter @forge/react aux packages automerge hors majeure

### DIFF
--- a/preset/automergeRecommendedNPM.json
+++ b/preset/automergeRecommendedNPM.json
@@ -13,10 +13,7 @@
       "description": "Automerge des packages de confiance, y compris en majeure",
       "matchManagers": ["npm"],
       "automerge": true,
-      "matchPackageNames": [
-        "lint-staged",
-        "uuid"
-      ]
+      "matchPackageNames": ["lint-staged", "uuid"]
     },
     {
       "description": "Automerge des packages de confiance, sauf en majeure",
@@ -55,7 +52,8 @@
         "react-syntax-highlighter",
         "react-select",
         "@lottiefiles/dotlottie-react",
-        "swiper"
+        "swiper",
+        "@forge/react"
       ]
     },
     {


### PR DESCRIPTION
Inclut @forge/react dans la liste des packages de confiance autorisés à merge automatiquement jusqu'à la prochaine majeure. Reformatage mineur du tableau matchPackageNames pour lint-staged/uuid.