### PR TITLE
🔧 Ajoute "internalChecksAsSuccess": true

### DIFF
--- a/base.json
+++ b/base.json
@@ -13,6 +13,7 @@
     "workarounds:all"
   ],
   "onboarding": false,
+  "internalChecksAsSuccess": true,
   "packageRules": [
     {
       "matchDepTypes": ["dependencies"],

--- a/test/__snapshots__/main.spec.ts.snap
+++ b/test/__snapshots__/main.spec.ts.snap
@@ -39,6 +39,7 @@ exports[`Configuration snapshot > base.json 1`] = `
     ":pinAllExceptPeerDependencies",
     "workarounds:all",
   ],
+  "internalChecksAsSuccess": true,
   "onboarding": false,
   "packageRules": [
     {


### PR DESCRIPTION
`internalChecksAsSuccess: true` fait **compter les checks internes de Renovate comme « réussis » (success) au lieu de « neutres » (neutral)**.

## Le détail

Renovate pose des checks « internes » sur la branche d'une PR, notamment :
- `renovate/stability-days` → lié à `minimumReleaseAge` (le délai de maturité : 2 j / 7 j chez vous)
- `renovate/merge-confidence` → si configuré

Par défaut (`internalChecksAsSuccess: false`), une fois la condition remplie (ex : le délai d'âge écoulé), Renovate considère ce check comme **neutral**, pas comme **success**.

## Pourquoi c'est le bug

`renovate/stability-days` est un **GitHub StatusContext** (confirmé sur la PR puma : `"__typename":"StatusContext"`). Or un StatusContext n'a que 3 états possibles : `pending` / `success` / `failure` — **il n'existe pas d'état « neutral »**.

Donc avec le défaut `false` :
- Renovate veut le mettre en « neutral »
- mais « neutral » est impossible sur un StatusContext
- → le check **reste bloqué en `pending` pour toujours**, même après l'écoulement du délai
- → `mergeStateStatus: UNSTABLE` → l'automerge ne se déclenche jamais → la PR stagne dans « Pending Status Checks »

Avec `true` :
- une fois le délai écoulé, Renovate fait passer le check à **`success`**
- → la PR devient mergeable, `platformAutomerge` s'exécute

## Ce que ça ne change PAS

Le délai `minimumReleaseAge` lui-même est conservé : une mise à jour attend toujours ses 2 j (minor/patch) ou 7 j (major) avant que le check passe au vert. On corrige uniquement **comment le résultat est reporté** (success au lieu de neutral/pending bloquant), pas la durée d'attente.

Doc Renovate, mot pour mot : *« Configure this to convert internal check statuses from neutral to success. »*