### PR TITLE
✨ Ajoute la catégorie "⚠ Décisions à prendre (checks rouges, automerge désactivé) :"

### DIFF
--- a/automerge-renovate/lib/automerge_renovate/failed_checks_rerunner.rb
+++ b/automerge-renovate/lib/automerge_renovate/failed_checks_rerunner.rb
@@ -11,7 +11,7 @@ module AutomergeRenovate
     end
 
     def call(repo, pr, decision)
-      return decision unless decision[:needs_investigation]
+      return decision unless decision[:needs_investigation] || decision[:needs_decision_red]
 
       run_ids = run_ids_for(pr)
       return decision.merge(rerun_triggered: false) if run_ids.empty?

--- a/automerge-renovate/lib/automerge_renovate/pr_decision.rb
+++ b/automerge-renovate/lib/automerge_renovate/pr_decision.rb
@@ -20,7 +20,7 @@ module AutomergeRenovate
           return { action: :skip, reason: "automerge désactivé", needs_decision: true }
         end
 
-        return { action: :skip, reason: "automerge désactivé" }
+        return { action: :skip, reason: "automerge désactivé", needs_decision_red: true }
       end
 
       return { action: :rebase_requested } if merge_state_status == "BEHIND"

--- a/automerge-renovate/lib/automerge_renovate/progress_printer.rb
+++ b/automerge-renovate/lib/automerge_renovate/progress_printer.rb
@@ -38,6 +38,7 @@ module AutomergeRenovate
 
       decision_header = "⚠ Décisions à prendre (checks verts, automerge désactivé) :"
       print_flagged(results, :needs_decision, decision_header)
+      print_flagged(results, :needs_decision_red, "⚠ Décisions à prendre (checks rouges, automerge désactivé) :")
       print_flagged(results, :needs_investigation, "⚠ PR à investiguer (checks rouges) :")
     end
 

--- a/automerge-renovate/spec/failed_checks_rerunner_spec.rb
+++ b/automerge-renovate/spec/failed_checks_rerunner_spec.rb
@@ -66,5 +66,23 @@ RSpec.describe AutomergeRenovate::FailedChecksRerunner do
 
       expect(result).to eq(decision.merge(rerun_triggered: false))
     end
+
+    it "redéclenche aussi le job en échec pour une PR désactivée avec des checks rouges" do
+      pr = {
+        "statusCheckRollup" => [
+          {
+            "__typename" => "CheckRun", "conclusion" => "FAILURE",
+            "detailsUrl" => "https://github.com/captive-studio/monocle/actions/runs/456/job/1",
+          },
+        ],
+      }
+      decision = { action: :skip, reason: "automerge désactivé", needs_decision_red: true }
+      allow(gh).to receive(:rerun_failed_jobs)
+
+      result = rerunner.call("captive-studio/monocle", pr, decision)
+
+      expect(gh).to have_received(:rerun_failed_jobs).with("captive-studio/monocle", "456")
+      expect(result).to eq(decision.merge(rerun_triggered: true))
+    end
   end
 end

--- a/automerge-renovate/spec/pr_decision_spec.rb
+++ b/automerge-renovate/spec/pr_decision_spec.rb
@@ -5,14 +5,14 @@ require "automerge_renovate/pr_decision"
 
 RSpec.describe AutomergeRenovate::PrDecision do
   describe "#call" do
-    it "ignore la PR quand l'automerge est désactivé et que les checks ne sont pas (tous) verts" do
+    it "signale needs_decision_red quand l'automerge est désactivé et que les checks ne sont pas (tous) verts" do
       pr = { "body" => "🚦 **Automerge**: Disabled by config.", "mergeStateStatus" => "CLEAN",
              "statusCheckRollup" => [ { "conclusion" => "FAILURE" } ], }
       merge_settings = { "allow_rebase_merge" => true }
 
       decision = described_class.new(pr, merge_settings).call
 
-      expect(decision).to eq(action: :skip, reason: "automerge désactivé")
+      expect(decision).to eq(action: :skip, reason: "automerge désactivé", needs_decision_red: true)
     end
 
     it "signale needs_decision quand l'automerge est désactivé mais que les checks sont verts" do

--- a/automerge-renovate/spec/progress_printer_spec.rb
+++ b/automerge-renovate/spec/progress_printer_spec.rb
@@ -76,5 +76,33 @@ RSpec.describe AutomergeRenovate::ProgressPrinter do
 
       expect(out.string).to include("https://github.com/captive-studio/groove-application/pull/7")
     end
+
+    it "affiche les PR désactivées à checks rouges, entre les décisions et les investigations" do
+      progress.summary(
+        [
+          { repo: "r1", number: 822, action: :skip, reason: "automerge désactivé", needs_decision_red: true,
+            url: "https://github.com/captive-studio/monocle/pull/822", },
+        ]
+      )
+
+      expect(out.string).to include("Décisions à prendre (checks rouges, automerge désactivé)")
+      expect(out.string).to include("https://github.com/captive-studio/monocle/pull/822")
+    end
+
+    it "liste les décisions (checks rouges) avant les investigations dans le résumé" do
+      progress.summary(
+        [
+          { repo: "r1", number: 822, action: :skip, reason: "automerge désactivé", needs_decision_red: true,
+            url: "https://github.com/captive-studio/monocle/pull/822", },
+          { repo: "r1", number: 7, action: :skip, reason: "checks non verts", needs_investigation: true,
+            url: "https://github.com/captive-studio/groove-application/pull/7", },
+        ]
+      )
+
+      decisions_red_index = out.string.index("Décisions à prendre (checks rouges, automerge désactivé)")
+      investigations_index = out.string.index("PR à investiguer")
+
+      expect(decisions_red_index).to be < investigations_index
+    end
   end
 end

--- a/automerge-renovate/spec/runner_spec.rb
+++ b/automerge-renovate/spec/runner_spec.rb
@@ -95,10 +95,34 @@ RSpec.describe AutomergeRenovate::Runner do
       results = runner.run([ "captive-studio/monocle" ])
 
       expect(results).to eq(
-        [ { repo: "captive-studio/monocle", number: 42, url: nil, action: :skip, reason: "automerge désactivé" } ]
+        [
+          { repo: "captive-studio/monocle", number: 42, url: nil, action: :skip, reason: "automerge désactivé",
+            needs_decision_red: true, rerun_triggered: false, },
+        ]
       )
       expect(gh).not_to have_received(:merge)
       expect(gh).not_to have_received(:update_body)
+    end
+
+    it "redéclenche les checks rouges d'une PR désactivée et le signale dans le résultat" do
+      pr = { "number" => 822, "body" => "🚦 **Automerge**: Disabled by config.", "mergeStateStatus" => "CLEAN",
+             "statusCheckRollup" => [
+               { "conclusion" => "FAILURE",
+                 "detailsUrl" => "https://github.com/captive-studio/monocle/actions/runs/456/job/1", },
+             ], }
+      allow(gh).to receive(:open_renovate_prs).with("captive-studio/monocle").and_return([ pr ])
+      allow(gh).to receive(:merge_settings).with("captive-studio/monocle").and_return({})
+      allow(gh).to receive(:rerun_failed_jobs)
+
+      results = runner.run([ "captive-studio/monocle" ])
+
+      expect(gh).to have_received(:rerun_failed_jobs).with("captive-studio/monocle", "456")
+      expect(results).to eq(
+        [
+          { repo: "captive-studio/monocle", number: 822, url: nil, action: :skip, reason: "automerge désactivé",
+            needs_decision_red: true, rerun_triggered: true, },
+        ]
+      )
     end
 
     it "continue sur les autres PR quand gh échoue sur l'une d'elles" do


### PR DESCRIPTION
Les PR avec automerge désactivé ET checks rouges étaient ignorées sans jamais apparaître dans le résumé final. Ajoute le flag needs_decision_red pour les lister dans une catégorie dédiée, entre "Décisions à prendre" et "PR à investiguer", avec rerun automatique des checks rouges comme pour les autres PR à investiguer.

<img width="1325" height="630" alt="Capture d’écran 2026-07-22 à 11 36 11" src="https://github.com/user-attachments/assets/918d8174-93bd-4398-9fb2-d22e937dc115" />
