### PR TITLE
🐛 Débloquer les gems/packages bloqués en pending (minimumReleaseAgeBehaviour)

### DIFF
--- a/base.json
+++ b/base.json
@@ -19,17 +19,20 @@
     {
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["major"],
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "7 days",
+      "minimumReleaseAgeBehaviour": "timestamp-optional"
     },
     {
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["minor"],
-      "minimumReleaseAge": "2 days"
+      "minimumReleaseAge": "2 days",
+      "minimumReleaseAgeBehaviour": "timestamp-optional"
     },
     {
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["patch"],
-      "minimumReleaseAge": "2 days"
+      "minimumReleaseAge": "2 days",
+      "minimumReleaseAgeBehaviour": "timestamp-optional"
     }
   ],
   "prConcurrentLimit": 5,

--- a/preset/groupAlveole.json
+++ b/preset/groupAlveole.json
@@ -6,7 +6,8 @@
       "groupName": "[NPM] Alveole",
       "matchManagers": ["npm"],
       "matchPackagePrefixes": ["@alveole/"],
-      "minimumReleaseAge": "1 day"
+      "minimumReleaseAge": "1 day",
+      "minimumReleaseAgeBehaviour": "timestamp-optional"
     },
     {
       "matchUpdateTypes": ["minor", "patch"],

--- a/preset/groupExpo.json
+++ b/preset/groupExpo.json
@@ -38,7 +38,8 @@
       "description": "Attendre 45 jours avant de merger une mise a jour majeure d'Expo",
       "matchPackagePatterns": ["^(@expo|expo)($|[-/])"],
       "matchUpdateTypes": ["major"],
-      "minimumReleaseAge": "45 days"
+      "minimumReleaseAge": "45 days",
+      "minimumReleaseAgeBehaviour": "timestamp-optional"
     },
     {
       "matchPackageNames": ["expo"],

--- a/preset/groupRuby.json
+++ b/preset/groupRuby.json
@@ -11,6 +11,7 @@
         "ghcr.io/captive-studio/ruby-ci"
       ],
       "minimumReleaseAge": "3 days",
+      "minimumReleaseAgeBehaviour": "timestamp-optional",
       "automerge": true
     }
   ]


### PR DESCRIPTION
## Contexte

Renovate maintient les packages en état « pending » indéfiniment quand il ne peut pas récupérer leur timestamp de publication. Le comportement par défaut de `minimumReleaseAgeBehaviour` est `timestamp-required` : sans timestamp, impossible de vérifier l'âge minimum, donc la PR n'est jamais créée.

Ce bug touche les gems Ruby hébergées sur GitHub, certains packages npm privés, et tout registre n'exposant pas de date de publication.

## Solution

Ajouter `"minimumReleaseAgeBehaviour": "timestamp-optional"` sur toutes les règles `minimumReleaseAge` du repo. Avec cette valeur, l'absence de timestamp n'est plus bloquante : Renovate crée la PR directement. Si le timestamp est présent, la règle `minimumReleaseAge` s'applique normalement.

Ce workaround est déjà en place dans `preset/ghcr.json` (GHCR n'expose pas de timestamps) — on l'étend aux autres presets.

## Fichiers modifiés

| Fichier | Règles concernées |
|---|---|
| `base.json` | major (7j), minor (2j), patch (2j) |
| `preset/groupRuby.json` | Ruby CI & Lang (3j) |
| `preset/groupAlveole.json` | @alveole/* npm (1j) |
| `preset/groupExpo.json` | major Expo (45j) |

Closes FAC-2436