### PR TITLE
✨ Distingue checks rouges (échec) et jaune (en attente) dans le résumé CLI

### DIFF
--- a/automerge-renovate/lib/automerge_renovate/checks_evaluator.rb
+++ b/automerge-renovate/lib/automerge_renovate/checks_evaluator.rb
@@ -3,6 +3,7 @@
 module AutomergeRenovate
   class ChecksEvaluator
     GREEN_CONCLUSIONS = %w[SUCCESS SKIPPED NEUTRAL].freeze
+    PENDING_STATUSES = %w[PENDING IN_PROGRESS QUEUED WAITING].freeze
 
     def initialize(checks)
       @checks = checks
@@ -10,6 +11,13 @@ module AutomergeRenovate
 
     def all_green?
       red_checks.empty?
+    end
+
+    def any_red?
+      @checks.any? do |check|
+        s = status_of(check)
+        s && !GREEN_CONCLUSIONS.include?(s) && !PENDING_STATUSES.include?(s)
+      end
     end
 
     def red_checks

--- a/automerge-renovate/lib/automerge_renovate/pr_decision.rb
+++ b/automerge-renovate/lib/automerge_renovate/pr_decision.rb
@@ -25,7 +25,7 @@ module AutomergeRenovate
 
       return { action: :rebase_requested } if merge_state_status == "BEHIND"
       unless checks_green?
-        return { action: :skip, reason: "checks non verts", needs_investigation: true }
+        return pending_checks_result
       end
       return { action: :rebase_requested } unless merge_state_status == "CLEAN"
 
@@ -41,8 +41,20 @@ module AutomergeRenovate
       AutomergeStatus.new(@pr["body"]).enabled?
     end
 
+    def pending_checks_result
+      if checks_evaluator.any_red?
+        { action: :skip, reason: "checks non verts", needs_investigation: true }
+      else
+        { action: :skip, reason: "checks en attente", needs_wait: true }
+      end
+    end
+
     def checks_green?
-      ChecksEvaluator.new(@pr["statusCheckRollup"]).all_green?
+      checks_evaluator.all_green?
+    end
+
+    def checks_evaluator
+      @checks_evaluator ||= ChecksEvaluator.new(@pr["statusCheckRollup"])
     end
   end
 end

--- a/automerge-renovate/lib/automerge_renovate/progress_printer.rb
+++ b/automerge-renovate/lib/automerge_renovate/progress_printer.rb
@@ -40,6 +40,7 @@ module AutomergeRenovate
       print_flagged(results, :needs_decision, decision_header)
       print_flagged(results, :needs_decision_red, "⚠ Décisions à prendre (checks rouges, automerge désactivé) :")
       print_flagged(results, :needs_investigation, "⚠ PR à investiguer (checks rouges) :")
+      print_flagged(results, :needs_wait, "⚠ PR en attente (checks jaune) :")
     end
 
     private

--- a/automerge-renovate/spec/checks_evaluator_spec.rb
+++ b/automerge-renovate/spec/checks_evaluator_spec.rb
@@ -71,4 +71,39 @@ RSpec.describe AutomergeRenovate::ChecksEvaluator do
       expect(described_class.new([ green, red ]).red_checks).to eq([ red ])
     end
   end
+
+  describe "#any_red?" do
+    it "retourne true quand un check a échoué (conclusion FAILURE)" do
+      checks = [{ "__typename" => "CheckRun", "status" => "COMPLETED", "conclusion" => "FAILURE" }]
+
+      expect(described_class.new(checks).any_red?).to be(true)
+    end
+
+    it "retourne false quand un CheckRun est en cours (conclusion nil)" do
+      checks = [{ "__typename" => "CheckRun", "status" => "IN_PROGRESS", "conclusion" => nil }]
+
+      expect(described_class.new(checks).any_red?).to be(false)
+    end
+
+    it "retourne false quand un StatusContext est en attente (state PENDING)" do
+      checks = [{ "__typename" => "StatusContext", "context" => "renovate/stability-days", "state" => "PENDING" }]
+
+      expect(described_class.new(checks).any_red?).to be(false)
+    end
+
+    it "retourne true si un check est rouge parmi un check en cours" do
+      checks = [
+        { "__typename" => "CheckRun", "status" => "IN_PROGRESS", "conclusion" => nil },
+        { "__typename" => "CheckRun", "status" => "COMPLETED", "conclusion" => "FAILURE" },
+      ]
+
+      expect(described_class.new(checks).any_red?).to be(true)
+    end
+
+    it "retourne false quand tous les checks sont verts" do
+      checks = [{ "__typename" => "CheckRun", "status" => "COMPLETED", "conclusion" => "SUCCESS" }]
+
+      expect(described_class.new(checks).any_red?).to be(false)
+    end
+  end
 end

--- a/automerge-renovate/spec/pr_decision_spec.rb
+++ b/automerge-renovate/spec/pr_decision_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe AutomergeRenovate::PrDecision do
       expect(decision).to eq(action: :rebase_requested)
     end
 
-    it "ignore la PR quand un check n'est pas vert" do
+    it "ignore la PR quand un check a échoué (rouge)" do
       pr = { "body" => "🚦 **Automerge**: Enabled.", "mergeStateStatus" => "CLEAN",
              "statusCheckRollup" => [ { "conclusion" => "FAILURE" } ], }
       merge_settings = { "allow_rebase_merge" => true }
@@ -43,6 +43,16 @@ RSpec.describe AutomergeRenovate::PrDecision do
       decision = described_class.new(pr, merge_settings).call
 
       expect(decision).to eq(action: :skip, reason: "checks non verts", needs_investigation: true)
+    end
+
+    it "met la PR en attente quand les checks sont en cours sans échec (jaune)" do
+      pr = { "body" => "🚦 **Automerge**: Enabled.", "mergeStateStatus" => "CLEAN",
+             "statusCheckRollup" => [ { "status" => "IN_PROGRESS", "conclusion" => nil } ], }
+      merge_settings = { "allow_rebase_merge" => true }
+
+      decision = described_class.new(pr, merge_settings).call
+
+      expect(decision).to eq(action: :skip, reason: "checks en attente", needs_wait: true)
     end
 
     it "demande un rebase en cas de conflit (DIRTY) : Renovate résout en régénérant la branche" do

--- a/automerge-renovate/spec/progress_printer_spec.rb
+++ b/automerge-renovate/spec/progress_printer_spec.rb
@@ -74,7 +74,36 @@ RSpec.describe AutomergeRenovate::ProgressPrinter do
         ]
       )
 
+      expect(out.string).to include("PR à investiguer (checks rouges)")
       expect(out.string).to include("https://github.com/captive-studio/groove-application/pull/7")
+    end
+
+    it "affiche les PR dont les checks sont en cours (jaune)" do
+      progress.summary(
+        [
+          { repo: "r1", number: 12, action: :skip, reason: "checks en attente", needs_wait: true,
+            url: "https://github.com/captive-studio/groove-application/pull/12", },
+        ]
+      )
+
+      expect(out.string).to include("PR en attente (checks jaune)")
+      expect(out.string).to include("https://github.com/captive-studio/groove-application/pull/12")
+    end
+
+    it "liste les investigations (rouges) avant les attentes (jaune) dans le résumé" do
+      progress.summary(
+        [
+          { repo: "r1", number: 7, action: :skip, reason: "checks non verts", needs_investigation: true,
+            url: "https://github.com/captive-studio/groove-application/pull/7", },
+          { repo: "r1", number: 12, action: :skip, reason: "checks en attente", needs_wait: true,
+            url: "https://github.com/captive-studio/groove-application/pull/12", },
+        ]
+      )
+
+      investigations_index = out.string.index("PR à investiguer")
+      wait_index = out.string.index("PR en attente")
+
+      expect(investigations_index).to be < wait_index
     end
 
     it "affiche les PR désactivées à checks rouges, entre les décisions et les investigations" do


### PR DESCRIPTION


- ChecksEvaluator#any_red? détecte les vraies failures vs checks en cours
- PrDecision retourne needs_wait quand aucun rouge mais CI encore en cours
- ProgressPrinter affiche "⚠ PR en attente (checks jaune)" séparément